### PR TITLE
Memo 엔티티를 추가 합니다.

### DIFF
--- a/app/src/main/java/com/babysloth/memo/entity/Memo.kt
+++ b/app/src/main/java/com/babysloth/memo/entity/Memo.kt
@@ -1,0 +1,10 @@
+package com.babysloth.memo.entity
+
+data class Memo(
+    val id: Long = 0,
+    val createdAt: Long = 0,
+    val updatedAt: Long = 0,
+    val title: String = "",
+    val description: String = "",
+    val isBookmark: Boolean = false
+)


### PR DESCRIPTION
## 배경 
데이터베이스 저장돼 있는 데이터를 매핑하기 위한 Memo 엔티티를 추가 합니다.

## 수정사항
Memo 데이터 클래스에 다음 속성을 추가 했습니다:
```
id
생성 날짜
조회 날짜
타이틀
본문
isBookmark
```

## 논의사항 (optional) 
- isBookmark 속성에 대해 정규화를 할지 논의를 했지만 Memo 업데이트 할 때 부하가 될 정도로 많은 속성을 가지고 있지 않아 Memo 엔티티에 통합 하기로 함

## Github Issue
resolved #3