### PR TITLE
북마크 목록 화면을 추가합니다.

### DIFF
--- a/app/src/main/java/com/babysloth/memo/MemoApplication.kt
+++ b/app/src/main/java/com/babysloth/memo/MemoApplication.kt
@@ -1,7 +1,6 @@
 package com.babysloth.memo
 
 import android.app.Application
-import android.content.Context
 import com.babysloth.memo.data.database.MemoRoomDatabase
 
 class MemoApplication : Application() {
@@ -16,9 +15,5 @@ class MemoApplication : Application() {
     companion object {
         lateinit var INSTANCE: MemoApplication
             private set
-
-        fun context(): Context {
-            return INSTANCE.applicationContext
-        }
     }
 }

--- a/app/src/main/java/com/babysloth/memo/ui/view/MainActivity.kt
+++ b/app/src/main/java/com/babysloth/memo/ui/view/MainActivity.kt
@@ -26,6 +26,7 @@ import androidx.navigation.compose.rememberNavController
 import com.babysloth.memo.R
 import com.babysloth.memo.ui.theme.*
 import com.babysloth.memo.ui.view.MainActivity.BottomNavigationItem.*
+import com.babysloth.memo.ui.view.bookmark.BookmarkScreen
 
 class MainActivity : ComponentActivity() {
 
@@ -118,24 +119,6 @@ class MainActivity : ComponentActivity() {
         }
     }
 
-
-    @Composable
-    fun Bookmarks() {
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(Yellow200)
-        ) {
-            Text(
-                text = stringResource(id = R.string.bookmarks),
-                style = MaterialTheme.typography.h3,
-                textAlign = TextAlign.Center,
-                color = Brown800,
-                modifier = Modifier.align(Alignment.Center)
-            )
-        }
-    }
-
     @Composable
     fun Settings() {
         Box(
@@ -169,7 +152,7 @@ class MainActivity : ComponentActivity() {
         ) {
             composable(NewMemo.screenRoute) { NewMemo() }
             composable(MemoList.screenRoute) { MemoList() }
-            composable(Bookmarks.screenRoute) { Bookmarks() }
+            composable(Bookmarks.screenRoute) { BookmarkScreen() }
             composable(Settings.screenRoute) { Settings() }
         }
 

--- a/app/src/main/java/com/babysloth/memo/ui/view/bookmark/BookmarkScreen.kt
+++ b/app/src/main/java/com/babysloth/memo/ui/view/bookmark/BookmarkScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -21,10 +22,21 @@ import com.babysloth.memo.domain.model.Memo
 fun BookmarkScreen(bookmarkViewModel: BookmarkViewModel = viewModel()) {
     val uiState by bookmarkViewModel.uiState.collectAsState()
 
-    LazyColumn(modifier = Modifier.fillMaxSize()) {
-        items(uiState.memos) { memo ->
-            BookmarkItem(memo = memo)
+    when(uiState.result) {
+        is BookmarkState.Fail -> {
+            Text(text = (uiState.result as BookmarkState.Fail).message)
         }
+        BookmarkState.Loading -> {
+            CircularProgressIndicator()
+        }
+        BookmarkState.Success -> {
+            LazyColumn(modifier = Modifier.fillMaxSize()) {
+                items(uiState.memos) { memo ->
+                    BookmarkItem(memo = memo)
+                }
+            }
+        }
+        BookmarkState.Uninitialized -> Unit
     }
 }
 
@@ -42,7 +54,5 @@ fun BookmarkItem(memo: Memo, modifier: Modifier = Modifier) {
 @Preview(showBackground = true)
 @Composable
 fun BookmarkScreenPreview() {
-    Column(modifier = Modifier.fillMaxSize()) {
-        BookmarkItem(memo = Memo(title = "나는 메모 외롭지 않아"))
-    }
+    CircularProgressIndicator()
 }

--- a/app/src/main/java/com/babysloth/memo/ui/view/bookmark/BookmarkScreen.kt
+++ b/app/src/main/java/com/babysloth/memo/ui/view/bookmark/BookmarkScreen.kt
@@ -1,0 +1,48 @@
+package com.babysloth.memo.ui.view.bookmark
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.babysloth.memo.domain.model.Memo
+
+@Composable
+fun BookmarkScreen(bookmarkViewModel: BookmarkViewModel = viewModel()) {
+    val uiState by bookmarkViewModel.uiState.collectAsState()
+
+    LazyColumn(modifier = Modifier.fillMaxSize()) {
+        items(uiState.memos) { memo ->
+            BookmarkItem(memo = memo)
+        }
+    }
+}
+
+@Composable
+fun BookmarkItem(memo: Memo, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .size(100.dp)
+    ) {
+        Text(text = memo.title)
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun BookmarkScreenPreview() {
+    Column(modifier = Modifier.fillMaxSize()) {
+        BookmarkItem(memo = Memo(title = "나는 메모 외롭지 않아"))
+    }
+}

--- a/app/src/main/java/com/babysloth/memo/ui/view/bookmark/BookmarkState.kt
+++ b/app/src/main/java/com/babysloth/memo/ui/view/bookmark/BookmarkState.kt
@@ -1,0 +1,8 @@
+package com.babysloth.memo.ui.view.bookmark
+
+sealed class BookmarkState {
+    object Uninitialized : BookmarkState()
+    object Loading : BookmarkState()
+    data class Fail(val message: String) : BookmarkState()
+    object Success : BookmarkState()
+}

--- a/app/src/main/java/com/babysloth/memo/ui/view/bookmark/BookmarkUiState.kt
+++ b/app/src/main/java/com/babysloth/memo/ui/view/bookmark/BookmarkUiState.kt
@@ -4,5 +4,5 @@ import com.babysloth.memo.domain.model.Memo
 import kotlinx.coroutines.flow.Flow
 
 data class BookmarkUiState(
-    val memos: List<Memo>? = null
+    val memos: List<Memo> = emptyList()
 )

--- a/app/src/main/java/com/babysloth/memo/ui/view/bookmark/BookmarkUiState.kt
+++ b/app/src/main/java/com/babysloth/memo/ui/view/bookmark/BookmarkUiState.kt
@@ -4,5 +4,6 @@ import com.babysloth.memo.domain.model.Memo
 import kotlinx.coroutines.flow.Flow
 
 data class BookmarkUiState(
-    val memos: List<Memo> = emptyList()
+    val memos: List<Memo> = emptyList(),
+    val result: BookmarkState = BookmarkState.Uninitialized
 )

--- a/app/src/main/java/com/babysloth/memo/ui/view/bookmark/BookmarkViewModel.kt
+++ b/app/src/main/java/com/babysloth/memo/ui/view/bookmark/BookmarkViewModel.kt
@@ -14,17 +14,15 @@ class BookmarkViewModel : ViewModel() {
     private val _uiState = MutableStateFlow(BookmarkUiState())
 
     //TODO: DI 적용 필요
-    private var repository: RoomMemoRepository
-    private var bookmarkUseCase: GetBookmarkUseCase
+    private var repository: RoomMemoRepository = RoomMemoRepository(
+        MemoApplication.INSTANCE.database.memoDao()
+    )
+    private var bookmarkUseCase: GetBookmarkUseCase = GetBookmarkUseCase(repository)
 
     val uiState = _uiState.asStateFlow()
 
     init {
         //TODO: DI 적용 필요
-        repository = RoomMemoRepository(
-            MemoApplication.INSTANCE.database.memoDao()
-        )
-        bookmarkUseCase = GetBookmarkUseCase(repository)
 
         viewModelScope.launch {
             bookmarkUseCase.getBookmarks()

--- a/app/src/main/java/com/babysloth/memo/ui/view/bookmark/BookmarkViewModel.kt
+++ b/app/src/main/java/com/babysloth/memo/ui/view/bookmark/BookmarkViewModel.kt
@@ -22,8 +22,6 @@ class BookmarkViewModel : ViewModel() {
     val uiState = _uiState.asStateFlow()
 
     init {
-        //TODO: DI 적용 필요
-
         viewModelScope.launch {
             bookmarkUseCase.getBookmarks()
                 .collect { memos ->


### PR DESCRIPTION
## 배경 
네비게이션 하단 북마크 메뉴를 눌렀을 때 북마크된 메모 목록 화면을 볼 수 있습니다.

|성공|에러|
|----|----|
|<img width="364" alt="image" src="https://user-images.githubusercontent.com/481800/233083124-76bebea8-424b-46ba-8d91-4fcdf17487f6.png">|<img width="363" alt="image" src="https://user-images.githubusercontent.com/481800/233083017-0fa3a148-3b97-41f9-990a-e729e95e5b80.png">|

## 수정사항 
- 뷰모델에서 레파지토리의 북마크 목록을 불러올 때 사용되는 UiState 추가
- 룸 요청 사항에 대한 상태를 나타내는 Uninitialized, Success, Fail, Loading 추가
- 상태에 맞는 뷰 화면 목업 추가
- LazyColumn으로 목록 화면 구성

## 논의사항 (optional) 
- State를 공용으로 만들지 논의 하다 이후 다른 곳에서 쓰일 상황이 발생하면 그때 논의 하기로 함.

## Github Issue
Resolved #11 